### PR TITLE
Simplify prompt to deploy open files

### DIFF
--- a/apex-plugin/apex.vim
+++ b/apex-plugin/apex.vim
@@ -580,7 +580,7 @@ function! s:prepareFileDescriptor(projectPath, type, filePath )
 			endif	
 		endfor	
 		" check if user is happy to deploy prepared files
-		let response = input('Deploy [y/n]? ', 'N')
+		let response = input('Deploy [y/N]? ')
 		if 'y' == response || 'Y' == response
 		else
 			"ensure blank line


### PR DESCRIPTION
Default is still No, but the user no longer needs to delete the 'N' to
enter 'y' or 'Y'.
