### PR TITLE
Escaped password when saving .properties file

### DIFF
--- a/apex-plugin/apexProject.vim
+++ b/apex-plugin/apexProject.vim
@@ -68,7 +68,7 @@ function s:buildPropertiesFile(projectName) abort
 
 		let fileLines = []
 		call add(fileLines, 'sf.username = ' . username)
-		call add(fileLines, 'sf.password = ' . password . token)
+		call add(fileLines, 'sf.password = ' . escape(password,'\') . token)
 		call add(fileLines, 'sf.serverurl = https://' . orgType . '.salesforce.com')
 		call writefile(fileLines, propertiesFilePath)
 	endif


### PR DESCRIPTION
If the user's password contains a '\', it will be stored verbatim in the project's .properties file. When this file is read by the Properties class in tooling-force.com.jar, this will be interpreted as an escaping character (see: http://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#load%28java.io.Reader%29) and the authentication won't work, since the '\' dropped in any case.

This is what happened to me :) 

To fix this I added an invocation to the escape() function to escape the '\' in the apexProject.vim file, where the password is stored.
