### PR TITLE
Set filetype for custom metadata

### DIFF
--- a/ftdetect/vim-force.com.vim
+++ b/ftdetect/vim-force.com.vim
@@ -26,7 +26,7 @@ augroup apexXml
     au BufRead,BufNewFile */src/layouts/*.layout set filetype=apexcode.xml | set syntax=xml
     au BufRead,BufNewFile */src/workflows/*.workflow set filetype=apexcode.xml | set syntax=xml
     au BufRead,BufNewFile */src/package.xml set filetype=apexcode.xml | set syntax=xml
-    au BufRead,BufNewFile */customMetadata/*.md set filetype=apexcode.xml | set syntax=xml
+    au BufRead,BufNewFile */src/customMetadata/*.md set filetype=apexcode.xml | set syntax=xml
 augroup END
 
 " unpacked resources are stored in projet_root/resources_unpacked/... folder

--- a/ftdetect/vim-force.com.vim
+++ b/ftdetect/vim-force.com.vim
@@ -26,6 +26,7 @@ augroup apexXml
     au BufRead,BufNewFile */src/layouts/*.layout set filetype=apexcode.xml | set syntax=xml
     au BufRead,BufNewFile */src/workflows/*.workflow set filetype=apexcode.xml | set syntax=xml
     au BufRead,BufNewFile */src/package.xml set filetype=apexcode.xml | set syntax=xml
+    au BufRead,BufNewFile */customMetadata/*.md set filetype=apexcode.xml | set syntax=xml
 augroup END
 
 " unpacked resources are stored in projet_root/resources_unpacked/... folder


### PR DESCRIPTION
Vim detects files with the .md extension as Markdown files, for obvious reasons.

This PR adds to the filetype auto commands to set it to apexcode.xml.